### PR TITLE
Fix typo in comments from "EJERCICOS" to "EJERCICIOS"

### DIFF
--- a/02_flow_control/01_if.py
+++ b/02_flow_control/01_if.py
@@ -139,7 +139,7 @@ mensaje = "Es mayor de edad" if edad >= 18 else "Es menor de edad"
 print(mensaje)
 
 ###
-# EJERCICOS
+# EJERCICIOS
 ###
 
 # Ejercicio 1: Determinar el mayor de dos números

--- a/02_flow_control/01_if_solutions.py
+++ b/02_flow_control/01_if_solutions.py
@@ -1,5 +1,5 @@
 ###
-# EJERCICOS
+# EJERCICIOS
 ###
 
 # Ejercicio 1: Determinar el mayor de dos números

--- a/02_flow_control/03_list.py
+++ b/02_flow_control/03_list.py
@@ -64,7 +64,7 @@ print(lista1)
 print("Longitud de la lista", len(lista1))
 
 ###
-# EJERCICOS
+# EJERCICIOS
 ###
 
 # Ejercicio 1: El mensaje secreto

--- a/02_flow_control/04_list_methods.py
+++ b/02_flow_control/04_list_methods.py
@@ -71,7 +71,7 @@ print('🐼' in animals) # Comprueba si hay un '🐼' en la lista -> True
 print('🐹' in animals) # -> False
 
 ###
-# EJERCICOS
+# EJERCICIOS
 # Usa siempre que puedas los métodos que has aprendido
 ###
 

--- a/02_flow_control/04_list_methods_solutions.py
+++ b/02_flow_control/04_list_methods_solutions.py
@@ -1,5 +1,5 @@
 ###
-# EJERCICOS
+# EJERCICIOS
 ###
 
 # Ejercicio 1: Añadir y modificar elementos


### PR DESCRIPTION
This PR fixes a typo in comments across multiple files, changing "EJERCICOS" to "EJERCICIOS"